### PR TITLE
Add GOGS configuration file

### DIFF
--- a/files/app.ini
+++ b/files/app.ini
@@ -1,0 +1,30 @@
+RUN_USER = vagrant
+RUN_MODE = prod
+
+[database]
+DB_TYPE = mysql
+HOST = 127.0.0.1:3306
+NAME = gogs
+USER = admin
+PASSWD = Passw0rd!
+SSL_MODE = disable
+PATH = data/gogs.db
+
+[repository]
+ROOT = /home/vagrant/gogs-repositories
+
+[server]
+DOMAIN = localhost
+HTTP_PORT = 3000
+ROOT_URL = http://localhost:3000/
+
+[session]
+PROVIDER = file
+
+[log]
+MODE = file
+LEVEL = Info
+
+[security]
+INSTALL_LOCK = true
+SECRET_KEY = 1NS3SccBDywrYAa

--- a/plays/book-ci-compact.yml
+++ b/plays/book-ci-compact.yml
@@ -37,3 +37,4 @@
     - include: install_gogs.yml
       vars:
         zip_filename: gogs_v0.6.1_linux_amd64.zip
+        config_filename: app.ini

--- a/plays/install_gogs.yml
+++ b/plays/install_gogs.yml
@@ -11,7 +11,10 @@
   - name: Creating the GOGS "custom/conf" folder
     file: path=/usr/local/gogs/custom/conf state=directory owner=vagrant mode=0777
 
-  - name: Creating the GOGS "log" folder
+  - name: Copying GOGS custom configuration file
+    copy: src=cache/{{config_filename}} dest=/usr/local/gogs/custom/conf/{{config_filename}}
+
+    - name: Creating the GOGS "log" folder
     file: path=/usr/local/gogs/log state=directory owner=vagrant mode=0777
 
   - name: Removing the GOGS archive


### PR DESCRIPTION
Add GOGS configuration file.  When GOGS is run, it will pick up the configuration file and the user will only be required to register in order to use GOGS.